### PR TITLE
ISO Listing enhancement (W11 LTSC fix)

### DIFF
--- a/WimWizard.ps1
+++ b/WimWizard.ps1
@@ -406,7 +406,7 @@ if ($PatchMode) {
 # Trap ensures ISOs are always dismounted even if the script exits early (Ctrl+C, error, user cancel)
 trap {
     Write-Host ""
-    Write-Fail "Unhandled error: $($_.Exception.Message)"
+    Write-Fail "Unhandled error (Line $($_.InvocationInfo.ScriptLineNumber)): $($_.Exception.Message)"
     Dismount-AllISOs
     break
 }
@@ -592,7 +592,7 @@ function Resolve-SourceFolder {
     Get-ChildItem $Folder -Filter "*.iso" -ErrorAction SilentlyContinue | ForEach-Object {
         $isoFiles += $_
     }
-    
+
     if (-not $isoFiles -or $isoFiles.Count -eq 0) {
         return $null
     }

--- a/WimWizard.ps1
+++ b/WimWizard.ps1
@@ -588,8 +588,11 @@ function Dismount-AllISOs {
 function Resolve-SourceFolder {
     param([string]$Folder, [switch]$SkipLP)
 
-    $isoFiles = Get-ChildItem $Folder -Filter "*.iso" -ErrorAction SilentlyContinue
-
+    $isoFiles = @()
+    Get-ChildItem $Folder -Filter "*.iso" -ErrorAction SilentlyContinue | ForEach-Object {
+        $isoFiles += $_
+    }
+    
     if (-not $isoFiles -or $isoFiles.Count -eq 0) {
         return $null
     }


### PR DESCRIPTION
This PR changes the way ISOs are listed by initializing the array beforehand, this fixes an error if there is only one ISO and the .Count method does not work.

Included fixes
1. Fixes #2 
2. Added additional output for exception handling to show the actual error line